### PR TITLE
feat: improve skill scores for QuickDesk

### DIFF
--- a/quickdesk-skill-host/skills/file-ops/SKILL.md
+++ b/quickdesk-skill-host/skills/file-ops/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: file-ops
-description: Browse, read, and write files on the remote host machine.
+description: "Read, write, list, move, and inspect files and directories on a remote host via QuickDesk. Use when the user needs to browse folders, view file contents, create or edit files, rename or relocate files, or check file metadata (size, permissions, modification time) on a remote machine."
 metadata:
   openclaw:
     os: ["win32", "darwin", "linux"]
@@ -12,16 +12,63 @@ metadata:
 
 # file-ops
 
-This skill provides file operation tools for the remote host:
+Manage files and directories on a remote host connected through QuickDesk.
 
-- `read_file` — read the contents of a file
-- `write_file` — write content to a file
-- `list_directory` — list files and directories at a given path
-- `create_directory` — create a directory
-- `move_file` — move or rename a file
-- `get_file_info` — get file metadata (size, modification time, permissions)
+## Tools
 
-## Usage
+### read_file
 
-The agent starts a Rust MCP server which exposes standard file operation
-tools. No external runtime required.
+Read the text contents of a file.
+
+- **path** (string, required) — absolute path to the file
+
+Returns `{ "path", "content", "size" }`.
+
+### write_file
+
+Write content to a file. Creates the file (and parent directories) if it does not exist; overwrites if it does.
+
+- **path** (string, required) — absolute path to the file
+- **content** (string, required) — content to write
+
+Returns `{ "path", "bytes_written" }`.
+
+### list_directory
+
+List files and directories at a given path, sorted directories-first then alphabetically.
+
+- **path** (string, required) — absolute path to the directory
+
+Returns `{ "path", "count", "entries": [{ "name", "type", "size" }] }`.
+
+### create_directory
+
+Create a directory and any missing parent directories.
+
+- **path** (string, required) — absolute path of the directory to create
+
+Returns `{ "path", "created": true }`.
+
+### move_file
+
+Move or rename a file or directory.
+
+- **source** (string, required) — source path
+- **destination** (string, required) — destination path
+
+Returns `{ "source", "destination", "moved": true }`.
+
+### get_file_info
+
+Get file metadata including size, type, modification time, and permissions.
+
+- **path** (string, required) — absolute path to the file or directory
+
+Returns `{ "path", "type", "size", "readonly", "modified_unix", "permissions_octal" }` (permissions_octal on Unix only).
+
+## Workflow
+
+1. Use `list_directory` to browse a remote folder.
+2. Use `read_file` to inspect a specific file.
+3. Use `write_file` to create or update content — parent directories are created automatically.
+4. Use `get_file_info` before destructive operations like `move_file` to confirm the target exists and check permissions.

--- a/quickdesk-skill-host/skills/shell-runner/SKILL.md
+++ b/quickdesk-skill-host/skills/shell-runner/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: shell-runner
-description: Execute shell commands on the remote host machine.
+description: "Execute shell commands on a remote host via QuickDesk and return stdout, stderr, and exit code. Use when the user asks to run a command, script, or terminal operation on a remote machine — supports configurable timeout and working directory."
 metadata:
   openclaw:
     os: ["win32", "darwin", "linux"]
@@ -12,12 +12,36 @@ metadata:
 
 # shell-runner
 
-This skill provides shell command execution on the remote host:
+Run shell commands on a remote host connected through QuickDesk. Commands execute via `cmd /C` on Windows or `sh -c` on Unix.
 
-- `run_command` — execute a shell command, returns stdout, stderr, and exit code
+## Tools
 
-## Usage
+### run_command
 
-The agent starts a Rust MCP server that executes commands via `cmd /C`
-(Windows) or `sh -c` (Unix). Supports configurable timeout and working
-directory.
+Execute a shell command on the remote host.
+
+- **command** (string, required) — the shell command to execute
+- **working_dir** (string, optional) — working directory for the command
+- **timeout_secs** (integer, optional) — timeout in seconds (default: 60)
+
+Returns:
+
+```json
+{
+  "exit_code": 0,
+  "stdout": "...",
+  "stderr": "...",
+  "stdout_truncated": false,
+  "stderr_truncated": false
+}
+```
+
+Output is truncated at 512 KB per stream if the command produces large output.
+
+## Workflow
+
+1. Call `run_command` with the desired command string.
+2. Check `exit_code` — 0 means success, non-zero indicates failure.
+3. If `exit_code` is non-zero, inspect `stderr` for error details.
+4. For long-running commands, increase `timeout_secs` beyond the 60-second default.
+5. Use `working_dir` to execute commands in a specific directory without changing global state.

--- a/quickdesk-skill-host/skills/sys-info/SKILL.md
+++ b/quickdesk-skill-host/skills/sys-info/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sys-info
-description: Get remote machine processes, CPU, memory, and system information.
+description: "Retrieve system information and list running processes on a remote host via QuickDesk. Use when the user asks to check server health, monitor CPU or memory usage, view disk space, list running processes, or query OS and uptime details on a remote machine."
 metadata:
   openclaw:
     os: ["win32", "darwin", "linux"]
@@ -12,12 +12,51 @@ metadata:
 
 # sys-info
 
-This skill provides system information tools for the remote host:
+Query system health and running processes on a remote host connected through QuickDesk.
 
-- `get_system_info` — OS version, CPU model, memory total/used, disk usage, hostname, uptime
-- `list_processes` — list running processes (name, pid, cpu%, memory)
+## Tools
 
-## Usage
+### get_system_info
 
-The agent starts a Rust MCP server that exposes system information via
-standard MCP tool calls. No user interaction required.
+Retrieve OS version, CPU model and usage, memory and swap totals/used, disk usage, hostname, and uptime. Takes no parameters.
+
+Returns:
+
+```json
+{
+  "os": "Ubuntu 22.04",
+  "kernel": "5.15.0",
+  "hostname": "prod-server-01",
+  "cpu": { "model": "AMD EPYC 7763", "cores": 8, "usage_percent": "12.3" },
+  "memory": { "total_mb": 16384, "used_mb": 8200, "usage_percent": "50.0" },
+  "swap": { "total_mb": 4096, "used_mb": 128 },
+  "disks": [{ "mount": "/", "total_gb": 500.0, "available_gb": 320.5, "fs": "ext4" }],
+  "uptime": "14h 32m"
+}
+```
+
+### list_processes
+
+List running processes with resource usage, sorted and limited.
+
+- **sort_by** (string, optional) — sort by `"cpu"`, `"memory"`, or `"name"` (default: `"cpu"`)
+- **limit** (integer, optional) — max number of processes to return (default: 50)
+
+Returns:
+
+```json
+{
+  "total_processes": 312,
+  "showing": 5,
+  "sort_by": "cpu",
+  "processes": [
+    { "pid": 1234, "name": "node", "cpu_percent": "45.2", "memory_mb": 512 }
+  ]
+}
+```
+
+## Workflow
+
+1. Call `get_system_info` to get an overview of the remote machine's health.
+2. If CPU or memory usage is high, call `list_processes` sorted by `"cpu"` or `"memory"` to identify the top consumers.
+3. Use `limit` to control result size when only the top offenders are needed.


### PR DESCRIPTION
Hullo @barry-ran 👋

I ran your skills through `tessl skill review` at work and found some targeted improvements. Here's the full before/after:

![Score Card](score_card.png)

| Skill | Before | After | Change |
|-------|--------|-------|--------|
| file-ops | 43% | 87% | +44% |
| shell-runner | 40% | 87% | +47% |
| sys-info | 54% | 93% | +39% |

<details>
<summary>Changes summary</summary>

**All three skills:**
- Expanded frontmatter descriptions with explicit "Use when..." clauses for better skill selection
- Added natural trigger terms users would actually say (e.g. "browse folders", "server health", "run a command")
- Included QuickDesk context to distinguish these from generic local-only skills

**file-ops:**
- Documented all 6 tools with parameter signatures (name, type, required) and return schemas
- Added a 4-step workflow: list → read → write → verify with `get_file_info` before destructive operations

**shell-runner:**
- Added full parameter documentation including `working_dir` and `timeout_secs` with defaults
- Included JSON return schema showing stdout/stderr/exit_code structure and truncation flags
- Added a 5-step workflow covering error handling via exit codes and stderr inspection

**sys-info:**
- Added complete JSON response examples for both `get_system_info` and `list_processes`
- Documented `sort_by` and `limit` parameters with allowed values and defaults
- Added a diagnostic workflow: overview → triage high usage → filter with limit

</details>

Honest disclosure — I work at @tesslio where we build tooling around skills like these. Not a pitch - just saw room for improvement and wanted to contribute.

Want to self-improve your skills? Just point your agent (Claude Code, Codex, etc.) at [this Tessl guide](https://docs.tessl.io/evaluate/optimize-a-skill-using-best-practices) and ask it to optimize your skill. Ping me - [@popey](https://github.com/popey) - if you hit any snags.

Thanks in advance 🙏